### PR TITLE
(fix) Keypad matrix connection to the pinout updated 

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,20 @@ Simple c++ code for digital road-books
 | green (row1, p10) | red-r           | yellow-f          | yellow-r          | red-f             |
 | red   (row2, p8)  | blue-f          | grey-f            | green-f           |                   |
 
+
+# keypad matrix v4
+|                  | grey (col1, p2) | white  (col2, p1) | brown  (col3, p0) | yellow (col4, p4) | 
+|------------------|-----------------|-------------------|-------------------|-------------------|
+| green (row1, p8) | red-r           | yellow-f          | yellow-r          | red-f             |
+| red   (row2, p6) | blue-f          | grey-f            | green-f           |                   |
+
+
+# keypad matrix v5
+|                  | grey (col1, p1) | white  (col2, p0) | brown  (col3, p4) | yellow (col4, p5) | 
+|------------------|-----------------|-------------------|-------------------|-------------------|
+| green (row1, p2) | red-r           | yellow-f          | yellow-r          | red-f             |
+| red   (row2, p3) | blue-f          | grey-f            | green-f           |                   |
+
 # Todo 
 - [ ] Profile switch 
 - [ ] Measure power usage
@@ -38,10 +52,16 @@ Simple c++ code for digital road-books
 # initial pre-modified keypad
 | button   | cable 1 | cable 2 |
 |----------|---------|---------|
-| red-r    | green   | black   |
-| yellow-r | green   | red     |
+| red-r    | black   | green   |
+| yellow-f | black   | white   |
+| yellow-r | red     | green   |
 | red-f    | red     | blue    |
 | grey-f   | red     | white   |
 | green-f  | red     | brown   |
-| yellow-f | white   | black   |
 | blue-f   | red     | yellow  |
+
+# initial pre-modified keypad keypad matrix proposal
+|                   | green (col1, p3) | blue  (col2, p2) | white  (col3, p1) | brown (col4, p0) | yellow (col5, p4) | 
+|-------------------|------------------|------------------|-------------------|------------------|-------------------|
+| red   (row2, p8)  | blue-f           | grey-f           | green-f           |                  |                   |
+| black (row1, p10) | red-r            | yellow-f         | yellow-r          | red-f            | red-f             |

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -72,8 +72,8 @@ public:
 const byte COLS = 4;
 const byte ROWS = 2;
 
-byte colPins[COLS] = {3, 2, 1, 4};
-byte rowPins[ROWS] = {10, 8};
+byte colPins[COLS] = {1, 0, 4, 5};
+byte rowPins[ROWS] = {2, 3};
 
 char hexaKeys[ROWS][COLS] = {
     {'1', '2', '3', '4'},


### PR DESCRIPTION
In order to reduce ghost press lets connect keypad to different set of pins